### PR TITLE
feat: upgraded pack_format for mc 1.21.4

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 57,
+		"pack_format": 61,
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the resource pack metadata to support a newer version of Minecraft.

Compatibility update:

* Increased the `pack_format` value in `pack.mcmeta` from 57 to 61 to ensure compatibility with the latest Minecraft versions.