### PR TITLE
feat: upgraded pack_format for mc 1.21.5

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 61,
+		"pack_format": 71,
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the `pack.mcmeta` metadata file to increase the `pack_format` version from 61 to 71. This ensures compatibility with newer versions of Minecraft and allows the resource pack to work with the latest game updates.

- Metadata update:
  * Increased the `pack_format` value in `pack.mcmeta` from 61 to 71 to support newer Minecraft versions.