### PR TITLE
feat: upgraded pack_format for mc 1.21.6

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 71,
+		"pack_format": 80,
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the `pack_format` version in the `pack.mcmeta` file to ensure compatibility with newer versions of Minecraft.

- Metadata update:
  * Increased the `pack_format` value from 71 to 80 in `pack.mcmeta` to support the latest Minecraft versions.