### PR TITLE
feat: upgraded pack_format for mc 1.21.8

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,6 @@
 {
 	"pack": {
-		"pack_format": 80,
+		"pack_format": 81,
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the resource pack metadata to ensure compatibility with the latest version of Minecraft.

Compatibility update:

* Increased the `pack_format` value from 80 to 81 in `pack.mcmeta` to support the latest Minecraft resource pack format.