### PR TITLE
feat: upgraded pack_format for mc 1.21.9 - 26.1.2

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,7 @@
 {
 	"pack": {
-		"pack_format": 81,
+		"min_format": 88,
+    	"max_format": 101.1,
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the pack metadata in `pack.mcmeta` to reflect new compatibility information for the resource pack. The key change is the replacement of the single `pack_format` field with `min_format` and `max_format`, indicating a supported range of formats rather than just one.

**Metadata compatibility update:**

* Replaced the `pack_format` field with `min_format` and `max_format` in `pack.mcmeta` to specify a supported range of Minecraft pack formats, improving clarity on version compatibility.