### PR TITLE
feat: update release order

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         variant:
           - { name: "Regular", prefix: "" }
-          - { name: "Fabric_Waystones", prefix: "fwaystones_" }
+          - { name: "Wraith_Waystones", prefix: "fwaystones_" }
           - { name: "Waystones", prefix: "waystone_" }
     steps:
       - uses: actions/checkout@v6
@@ -88,9 +88,9 @@ jobs:
     strategy:
       matrix:
         variant:
-          - { name: "Regular", dep: "[]" }
-          - { name: "Fabric_Waystones", dep: '[{"project_id":"sTZr7NVo","dependency_type":"required"}]' }
           - { name: "Waystones", dep: '[{"project_id":"LOpKHB2A","dependency_type":"required"}]' }
+          - { name: "Wraith_Waystones", dep: '[{"project_id":"sTZr7NVo","dependency_type":"required"}]' }
+          - { name: "Regular", dep: "[]" }
     steps:
       - uses: actions/download-artifact@v8
 
@@ -114,9 +114,9 @@ jobs:
     strategy:
       matrix:
         variant:
-          - { name: "Regular", dep: "" }
-          - { name: "Fabric_Waystones", dep: "fabric-waystones:requiredDependency" }
           - { name: "Waystones", dep: "waystones:requiredDependency" }
+          - { name: "Wraith_Waystones", dep: "fabric-waystones:requiredDependency" }
+          - { name: "Regular", dep: "" }
     steps:
       - uses: actions/download-artifact@v8
 


### PR DESCRIPTION
This pull request updates the release workflow configuration to replace the "Fabric_Waystones" variant with "Wraith_Waystones" across all relevant job matrices in the `.github/workflows/release.yml` file. The changes ensure that the new variant is consistently used for dependency and build steps.

Key changes:

**Variant updates:**

* Replaced the `Fabric_Waystones` variant with `Wraith_Waystones` in the build matrix, ensuring the new variant is built and released instead of the old one.

**Dependency configuration:**

* Updated the dependency matrix to use `Wraith_Waystones` (with the same project ID and dependency type as the former `Fabric_Waystones`), and adjusted the order of variants for clarity.
* Changed the dependency string for the new `Wraith_Waystones` variant in the relevant matrix, replacing the old `Fabric_Waystones` entry.