### PR TITLE
feat: dump max packformat for mc 26.2

### DIFF
--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,9 +1,9 @@
 {
 	"pack": {
 		"pack_format": 48,
-		"supported_formats": [48, 101],
+		"supported_formats": [48, 107],
 		"min_format": 48,
-		"max_format": [101, 1],
+		"max_format": [107, 1],
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the pack metadata to support newer Minecraft pack formats. The changes ensure compatibility with the latest versions by adjusting the supported and maximum format values.

Pack format compatibility updates:

* Updated the `supported_formats` array in `pack.mcmeta` to include format 107 instead of 101, expanding compatibility to newer Minecraft versions.
* Updated the `max_format` field in `pack.mcmeta` to `[107, 1]` instead of `[101, 1]`, reflecting the new maximum supported format.