### PR TITLE
feat: fix mc 26.2 naming

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,9 +10,9 @@ permissions:
   contents: write
 
 env:
-  MC_RANGE: "1.21-26.1.2"
-  MODRINTH_RANGE: ">=1.21 <=26.1.2"
-  CURSEFORGE_VERSIONS: "Minecraft 1.21:1.21,Minecraft 1.21:1.21.1,Minecraft 1.21:1.21.2,Minecraft 1.21:1.21.3,Minecraft 1.21:1.21.4,Minecraft 1.21:1.21.5,Minecraft 1.21:1.21.6,Minecraft 1.21:1.21.7,Minecraft 1.21:1.21.8,Minecraft 1.21:1.21.9,Minecraft 1.21:1.21.10,Minecraft 1.21:1.21.11,Minecraft 26.1:26.1,Minecraft 26.1:26.1.2"
+  MC_RANGE: "1.21-26.2"
+  MODRINTH_RANGE: ">=1.21 <=26.2"
+  CURSEFORGE_VERSIONS: "Minecraft 1.21:1.21,Minecraft 1.21:1.21.1,Minecraft 1.21:1.21.2,Minecraft 1.21:1.21.3,Minecraft 1.21:1.21.4,Minecraft 1.21:1.21.5,Minecraft 1.21:1.21.6,Minecraft 1.21:1.21.7,Minecraft 1.21:1.21.8,Minecraft 1.21:1.21.9,Minecraft 1.21:1.21.10,Minecraft 1.21:1.21.11,Minecraft 26.1:26.1,Minecraft 26.1:26.1.2,Minecraft 26.2:26.2"
 
 jobs:
   build:

--- a/build-release.sh
+++ b/build-release.sh
@@ -12,7 +12,7 @@ VARIANTS=(
   "Waystones|waystone_"
 )
 
-MC_RANGE="1.21-26.1.2"
+MC_RANGE="1.21-26.2"
 
 cleanup() {
   for type in "${TYPES[@]}"; do

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,9 +1,9 @@
 {
 	"pack": {
 		"pack_format": 48,
-		"supported_formats": [48, 101],
+		"supported_formats": [48, 107],
 		"min_format": 48,
-		"max_format": [101, 1],
+		"max_format": [107, 1],
 		"description": [
 			{
 				"text": "Adds Breath Of The Wild-like towers to make exploring a bit more fun!",


### PR DESCRIPTION
This pull request updates the project to support the latest Minecraft version 26.2 and its associated resource pack formats. The changes ensure compatibility with new versions across the build scripts, release workflow, and resource pack metadata.

Version compatibility updates:

* Updated `MC_RANGE`, `MODRINTH_RANGE`, and `CURSEFORGE_VERSIONS` in `.github/workflows/release.yml` to include support for Minecraft 26.2.
* Changed `MC_RANGE` in `build-release.sh` to extend support up to version 26.2.

Resource pack metadata updates:

* Updated `supported_formats` and `max_format` in `pack.mcmeta` to support resource pack format 107, aligning with Minecraft 26.2.