### PR TITLE
fix: corrected curseforge release version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 env:
   MC_RANGE: "1.21-26.2"
   MODRINTH_RANGE: ">=1.21 <=26.2"
-  CURSEFORGE_VERSIONS: "Minecraft 1.21:1.21,Minecraft 1.21:1.21.1,Minecraft 1.21:1.21.2,Minecraft 1.21:1.21.3,Minecraft 1.21:1.21.4,Minecraft 1.21:1.21.5,Minecraft 1.21:1.21.6,Minecraft 1.21:1.21.7,Minecraft 1.21:1.21.8,Minecraft 1.21:1.21.9,Minecraft 1.21:1.21.10,Minecraft 1.21:1.21.11,Minecraft 26.1:26.1,Minecraft 26.1:26.1.2,Minecraft 26.2:26.2"
+  CURSEFORGE_VERSIONS: "Minecraft 1.21:1.21,Minecraft 1.21:1.21.1,Minecraft 1.21:1.21.2,Minecraft 1.21:1.21.3,Minecraft 1.21:1.21.4,Minecraft 1.21:1.21.5,Minecraft 1.21:1.21.6,Minecraft 1.21:1.21.7,Minecraft 1.21:1.21.8,Minecraft 1.21:1.21.9,Minecraft 1.21:1.21.10,Minecraft 1.21:1.21.11,Minecraft 26.1:26.1,Minecraft 26.1:26.1.2,Minecraft 26.1:26.2"
 
 jobs:
   build:


### PR DESCRIPTION
This pull request makes a minor change to the `CURSEFORGE_VERSIONS` environment variable in the `.github/workflows/release.yml` file, correcting the version mapping for Minecraft 26.2 to be under Minecraft 26.1 instead of Minecraft 26.2.